### PR TITLE
Add message signing support for Rootstock and Spark networks

### DIFF
--- a/mobile/app/Settings.tsx
+++ b/mobile/app/Settings.tsx
@@ -20,6 +20,7 @@ import { SETTINGS_CONFIG } from '@shared/hooks/SettingsContext';
 import { useSettings } from '@shared/hooks/useSettings';
 import { capitalizeFirstLetter } from '@shared/modules/string-utils';
 import { STORAGE_KEY_BTC_XPUB, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
+import { NETWORK_ROOTSTOCK, NETWORK_SPARK } from '@shared/types/networks';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 
 const gitCommitHash = require('../git_commit_hash.json');
@@ -231,6 +232,16 @@ export default function SettingsScreen() {
           >
             <ThemedText style={styles.selfTestButtonText}>ScanQr</ThemedText>
           </TouchableOpacity>
+
+          {(network === NETWORK_ROOTSTOCK || network === NETWORK_SPARK) && (
+            <TouchableOpacity
+              style={[styles.button, styles.selfTestButton]}
+              onPress={() => router.push('/SignMessage')}
+              testID="SignMessageButton"
+            >
+              <ThemedText style={styles.selfTestButtonText}>Sign Message</ThemedText>
+            </TouchableOpacity>
+          )}
         </View>
 
         <ThemedText style={{ textAlign: 'center', color: 'rgba(255, 255, 255, 0.8)' }}>

--- a/mobile/app/SignMessage.tsx
+++ b/mobile/app/SignMessage.tsx
@@ -1,0 +1,328 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Stack, useRouter } from 'expo-router';
+import React, { useContext, useState, useEffect } from 'react';
+import { View, ScrollView, StyleSheet, TextInput, TouchableOpacity, Alert, Text, Clipboard } from 'react-native';
+
+import GradientScreen from '@/components/GradientScreen';
+import ScreenHeader from '@/components/navigation/ScreenHeader';
+import { ThemedText } from '@/components/ThemedText';
+import { AskPasswordContext } from '@/src/hooks/AskPasswordContext';
+import { BackgroundExecutor } from '@/src/modules/background-executor';
+import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
+import { NetworkContext } from '@shared/hooks/NetworkContext';
+import { NETWORK_ROOTSTOCK, NETWORK_SPARK } from '@shared/types/networks';
+
+const SignMessage = () => {
+  const router = useRouter();
+  const { network } = useContext(NetworkContext);
+  const { accountNumber } = useContext(AccountNumberContext);
+  const { askPassword } = useContext(AskPasswordContext);
+  
+  const [message, setMessage] = useState('');
+  const [signature, setSignature] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [address, setAddress] = useState('');
+
+  // This screen supports both Rootstock and Spark networks
+  const isRootstock = network === NETWORK_ROOTSTOCK;
+  const isSpark = network === NETWORK_SPARK;
+  const isSupported = isRootstock || isSpark;
+
+  // Fetch the wallet address on component mount
+  useEffect(() => {
+    const fetchAddress = async () => {
+      try {
+        const walletAddress = await BackgroundExecutor.getAddress(network, accountNumber);
+        setAddress(walletAddress);
+      } catch (error) {
+        console.error('Failed to fetch address:', error);
+      }
+    };
+    
+    if (isSupported) {
+      fetchAddress();
+    }
+  }, [network, accountNumber, isSupported]);
+
+  const handleSign = async () => {
+    if (!message.trim()) {
+      Alert.alert('Error', 'Please enter a message to sign');
+      return;
+    }
+
+    if (!isSupported) {
+      Alert.alert('Error', 'Message signing is only available on Rootstock and Spark networks');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const password = await askPassword();
+      
+      let result;
+      if (isRootstock) {
+        // Use EVM signing for Rootstock (it's an EVM-compatible chain)
+        result = await BackgroundExecutor.signPersonalMessage(
+          message,
+          accountNumber,
+          password
+        );
+      } else if (isSpark) {
+        // Use Spark-specific signing
+        result = await BackgroundExecutor.signSparkMessage(
+          message,
+          accountNumber,
+          password
+        );
+      }
+
+      if (result?.success) {
+        setSignature(result.bytes || result.signature);
+        Alert.alert('Success', 'Message signed successfully!');
+      } else {
+        throw new Error(result?.message || 'Failed to sign message');
+      }
+    } catch (error: any) {
+      Alert.alert('Error', error.message || 'Failed to sign message');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const copyToClipboard = () => {
+    if (signature) {
+      Clipboard.setString(signature);
+      Alert.alert('Copied', 'Signature copied to clipboard');
+    }
+  };
+
+  return (
+    <GradientScreen variant={network}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScreenHeader title="Sign Message" />
+
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.contentContainer}>
+          {isSupported ? (
+            <>
+              <ThemedText style={styles.description}>
+                Sign a message with your {isRootstock ? 'Rootstock' : 'Spark'} private key. This creates a cryptographic proof 
+                that you control this wallet address on the {isRootstock ? 'Rootstock' : 'Spark'} network.
+              </ThemedText>
+
+              {address ? (
+                <View style={styles.addressSection}>
+                  <ThemedText style={styles.addressLabel}>Your {isRootstock ? 'Rootstock' : 'Spark'} Address:</ThemedText>
+                  <View style={styles.addressContainer}>
+                    <Text style={styles.addressText}>{address}</Text>
+                  </View>
+                </View>
+              ) : null}
+
+              <View style={styles.inputSection}>
+                <ThemedText style={styles.inputLabel}>Message to Sign</ThemedText>
+                <TextInput
+                  style={styles.messageInput}
+                  placeholder="Enter your message here..."
+                  placeholderTextColor="rgba(255, 255, 255, 0.4)"
+                  value={message}
+                  onChangeText={setMessage}
+                  multiline
+                  textAlignVertical="top"
+                />
+              </View>
+
+              <TouchableOpacity
+                style={[styles.signButton, isLoading && styles.buttonDisabled]}
+                onPress={handleSign}
+                disabled={isLoading}
+              >
+                <Ionicons name="key-outline" size={20} color="rgba(255, 255, 255, 0.9)" />
+                <ThemedText style={styles.signButtonText}>
+                  {isLoading ? 'Signing...' : 'Sign Message'}
+                </ThemedText>
+              </TouchableOpacity>
+
+              {signature ? (
+                <View style={styles.resultSection}>
+                  <ThemedText style={styles.resultLabel}>{isRootstock ? 'Rootstock' : 'Spark'} Signature:</ThemedText>
+                  <View style={styles.signatureContainer}>
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                      <Text style={styles.signatureText}>{signature}</Text>
+                    </ScrollView>
+                  </View>
+                  <TouchableOpacity style={styles.copyButton} onPress={copyToClipboard}>
+                    <Ionicons name="copy-outline" size={18} color="rgba(255, 255, 255, 0.8)" />
+                    <ThemedText style={styles.copyButtonText}>Copy Signature</ThemedText>
+                  </TouchableOpacity>
+                </View>
+              ) : null}
+
+              <View style={styles.infoSection}>
+                <Ionicons name="information-circle-outline" size={20} color="rgba(255, 255, 255, 0.6)" />
+                <ThemedText style={styles.infoText}>
+                  This signature proves you control the private key for account #{accountNumber} on the {isRootstock ? 'Rootstock' : 'Spark'} network without revealing the key itself.
+                </ThemedText>
+              </View>
+            </>
+          ) : (
+            <View style={styles.unsupportedSection}>
+              <Ionicons name="alert-circle-outline" size={48} color="rgba(255, 255, 255, 0.4)" />
+              <ThemedText style={styles.unsupportedText}>
+                Message signing is only available when using the Rootstock or Spark networks.
+              </ThemedText>
+              <ThemedText style={styles.unsupportedSubtext}>
+                Please switch to Rootstock or Spark from the home screen to use this feature.
+              </ThemedText>
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </GradientScreen>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 16,
+  },
+  contentContainer: {
+    flex: 1,
+    paddingVertical: 20,
+  },
+  description: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  addressSection: {
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    borderRadius: 12,
+    padding: 15,
+    marginBottom: 30,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+  },
+  addressLabel: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  addressContainer: {
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    borderRadius: 8,
+    padding: 10,
+  },
+  addressText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontFamily: 'monospace',
+    fontSize: 13,
+  },
+  inputSection: {
+    marginBottom: 20,
+  },
+  inputLabel: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    marginBottom: 10,
+    fontWeight: '500',
+  },
+  messageInput: {
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    borderRadius: 12,
+    padding: 15,
+    color: 'rgba(255, 255, 255, 0.9)',
+    minHeight: 120,
+    fontSize: 14,
+  },
+  signButton: {
+    backgroundColor: '#000000',
+    borderRadius: 12,
+    paddingVertical: 15,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginBottom: 30,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  signButtonText: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontWeight: '600',
+  },
+  resultSection: {
+    backgroundColor: 'rgba(0, 255, 0, 0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(0, 255, 0, 0.2)',
+    borderRadius: 12,
+    padding: 15,
+    marginBottom: 30,
+  },
+  resultLabel: {
+    color: 'rgba(255, 255, 255, 0.7)',
+    marginBottom: 10,
+    fontSize: 12,
+  },
+  signatureContainer: {
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 10,
+  },
+  signatureText: {
+    color: 'rgba(0, 255, 0, 0.8)',
+    fontFamily: 'monospace',
+    fontSize: 12,
+  },
+  copyButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 8,
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    borderRadius: 8,
+  },
+  copyButtonText: {
+    color: 'rgba(255, 255, 255, 0.8)',
+    fontSize: 14,
+  },
+  infoSection: {
+    flexDirection: 'row',
+    gap: 10,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    padding: 15,
+    borderRadius: 12,
+  },
+  infoText: {
+    flex: 1,
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  unsupportedSection: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 60,
+  },
+  unsupportedText: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 16,
+    textAlign: 'center',
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  unsupportedSubtext: {
+    color: 'rgba(255, 255, 255, 0.4)',
+    fontSize: 14,
+    textAlign: 'center',
+    paddingHorizontal: 20,
+  },
+});
+
+export default SignMessage;

--- a/mobile/app/SignMessage.tsx
+++ b/mobile/app/SignMessage.tsx
@@ -77,7 +77,8 @@ const SignMessage = () => {
       }
 
       if (result?.success) {
-        setSignature(result.bytes || result.signature);
+        const sig = 'bytes' in result ? result.bytes : result.signature;
+        setSignature(sig);
         Alert.alert('Success', 'Message signed successfully!');
       } else {
         throw new Error(result?.message || 'Failed to sign message');

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -230,6 +230,42 @@ export const BackgroundExecutor: IBackgroundCaller = {
     }
   },
 
+  async signSparkMessage(message, accountNumber, password) {
+    const encryptedMnemonic = await SecureStorage.getItem(STORAGE_KEY_MNEMONIC);
+
+    if (!encryptedMnemonic.startsWith(ENCRYPTED_PREFIX)) {
+      return {
+        success: false,
+        signature: '',
+        message: 'Mnemonic is not encrypted. Please reinstall the app to fix this issue.',
+      };
+    }
+
+    try {
+      const deviceId = await getDeviceID(SecureStorage, Csprng);
+      const decrypted = await decrypt(encryptedMnemonic.replace(ENCRYPTED_PREFIX, ''), password, deviceId);
+      
+      // Import Spark SDK from the native module
+      const { SparkWallet: NativeSDK, ReactNativeSparkSigner } = require('@buildonspark/spark-sdk/native');
+      
+      // Initialize Spark wallet with the mnemonic
+      const { wallet } = await NativeSDK.initialize({
+        mnemonicOrSeed: decrypted as string,
+        signer: new ReactNativeSparkSigner(),
+        options: {
+          network: 'MAINNET',
+        },
+      });
+      
+      // Sign the message with the identity key
+      const signature = await wallet.signMessageWithIdentityKey(message);
+      
+      return { success: true, signature };
+    } catch (error: any) {
+      return { success: false, signature: '', message: error.message || 'Failed to sign message' };
+    }
+  },
+
   async openPopup(...params: OpenPopupRequest) {
     const bridge = BrowserBridge.getInstance();
     if (bridge) {

--- a/shared/tests/integration-vi/integration.test.ts
+++ b/shared/tests/integration-vi/integration.test.ts
@@ -49,6 +49,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   signTypedData() {
     throw new Error('Function not implemented.');
   },
+  signSparkMessage() {
+    throw new Error('Function not implemented.');
+  },
   getBtcSendData() {
     throw new Error('Function not implemented.');
   },

--- a/shared/tests/unit-vi/rpc-controller.test.ts
+++ b/shared/tests/unit-vi/rpc-controller.test.ts
@@ -80,6 +80,9 @@ const backgroundCallerMock2: IBackgroundCaller = {
   signTypedData() {
     throw new Error('Function not implemented.');
   },
+  signSparkMessage() {
+    throw new Error('Function not implemented.');
+  },
   getBtcSendData() {
     throw new Error('Function not implemented.');
   },

--- a/shared/types/IBackgroundCaller.ts
+++ b/shared/types/IBackgroundCaller.ts
@@ -98,6 +98,9 @@ export type SignPersonalMessageResponse = { bytes: string; success: boolean; mes
 export type SignTypedDataRequest = [message: any, accountNumber: number, password: string];
 export type SignTypedDataResponse = { bytes: string; success: boolean; message?: string };
 
+export type SignSparkMessageRequest = [message: string, accountNumber: number, password: string];
+export type SignSparkMessageResponse = { signature: string; success: boolean; message?: string };
+
 export type OpenPopupRequest = [method: string, params: any, id: number, from: string];
 
 export type GetBtcSendDataRequest = [accountNumber: number];
@@ -134,6 +137,7 @@ export interface IBackgroundCaller {
   log(...params: LogRequest): Promise<void>;
   signPersonalMessage(...params: SignPersonalMessageRequest): Promise<SignPersonalMessageResponse>;
   signTypedData(...params: SignTypedDataRequest): Promise<SignTypedDataResponse>;
+  signSparkMessage(...params: SignSparkMessageRequest): Promise<SignSparkMessageResponse>;
   openPopup(...params: OpenPopupRequest): Promise<void>;
   getBtcSendData(...params: GetBtcSendDataRequest): Promise<GetBtcSendDataResponse>;
   getSubMnemonic(...params: GetSubMnemonicRequest): Promise<GetSubMnemonicResponse>;


### PR DESCRIPTION
- Add SignMessage screen component with support for both networks
- Implement signSparkMessage function in BackgroundExecutor using Spark SDK
- Update Settings screen to show Sign Message button for Rootstock and Spark
- Display wallet address in SignMessage screen
- Add network-specific signing logic (EVM for Rootstock, Spark SDK for Spark)