### PR TITLE
Add Spark network message signing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # IDE
 .idea/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 
 # IDE
 .idea/
-.claude/settings.local.json

--- a/mobile/app/Settings.tsx
+++ b/mobile/app/Settings.tsx
@@ -21,6 +21,7 @@ import { useSettings } from '@shared/hooks/useSettings';
 import { capitalizeFirstLetter } from '@shared/modules/string-utils';
 import { STORAGE_KEY_BTC_XPUB, STORAGE_KEY_MNEMONIC } from '@shared/types/IStorage';
 import { getIsEVM } from '@shared/models/network-getters';
+import { NETWORK_SPARK } from '@shared/types/networks';
 import { BackgroundExecutor } from '@/src/modules/background-executor';
 
 const gitCommitHash = require('../git_commit_hash.json');
@@ -233,7 +234,7 @@ export default function SettingsScreen() {
             <ThemedText style={styles.selfTestButtonText}>ScanQr</ThemedText>
           </TouchableOpacity>
 
-          {network && getIsEVM(network) && (
+          {network && (getIsEVM(network) || network === NETWORK_SPARK) && (
             <TouchableOpacity
               style={[styles.button, styles.selfTestButton]}
               onPress={() => router.push('/SignMessage')}

--- a/mobile/app/SignMessage.tsx
+++ b/mobile/app/SignMessage.tsx
@@ -11,6 +11,7 @@ import { BackgroundExecutor } from '@/src/modules/background-executor';
 import { AccountNumberContext } from '@shared/hooks/AccountNumberContext';
 import { NetworkContext } from '@shared/hooks/NetworkContext';
 import { getIsEVM } from '@shared/models/network-getters';
+import { NETWORK_SPARK } from '@shared/types/networks';
 
 const SignMessage = () => {
   const router = useRouter();
@@ -23,24 +24,26 @@ const SignMessage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [address, setAddress] = useState<string>('');
 
-  // This screen is available for all EVM-compatible networks
-  // But we'll handle it gracefully if accessed from non-EVM networks
+  // This screen is available for all EVM-compatible networks and Spark
+  // But we'll handle it gracefully if accessed from unsupported networks
   const isEVMNetwork = network ? getIsEVM(network) : false;
+  const isSparkNetwork = network === NETWORK_SPARK;
+  const isSupported = isEVMNetwork || isSparkNetwork;
 
-  // Fetch the EVM address when component mounts or network/account changes
+  // Fetch the address when component mounts or network/account changes
   React.useEffect(() => {
     const fetchAddress = async () => {
-      if (isEVMNetwork && network) {
+      if (isSupported && network) {
         try {
-          const evmAddress = await BackgroundExecutor.getAddress(network, accountNumber);
-          setAddress(evmAddress);
+          const walletAddress = await BackgroundExecutor.getAddress(network, accountNumber);
+          setAddress(walletAddress);
         } catch (error) {
-          console.error('Failed to fetch EVM address:', error);
+          console.error('Failed to fetch address:', error);
         }
       }
     };
     fetchAddress();
-  }, [network, accountNumber, isEVMNetwork]);
+  }, [network, accountNumber, isSupported]);
 
   const handleSign = async () => {
     if (!message.trim()) {
@@ -48,24 +51,33 @@ const SignMessage = () => {
       return;
     }
 
-    if (!isEVMNetwork) {
-      Alert.alert('Error', 'Message signing is only available on EVM-compatible networks');
+    if (!isSupported) {
+      Alert.alert('Error', 'Message signing is only available on EVM-compatible networks and Spark');
       return;
     }
 
     setIsLoading(true);
     try {
-      const password = await askPassword();
-      
-      // Use EVM signing for all EVM-compatible chains
-      const result = await BackgroundExecutor.signPersonalMessage(
-        message,
-        accountNumber,
-        password
-      );
+      let result;
+      if (isSparkNetwork) {
+        // Spark doesn't need password as it uses unencrypted submnemonics
+        result = await BackgroundExecutor.signSparkMessage(
+          message,
+          accountNumber,
+          null // No password needed for Spark
+        );
+      } else {
+        // EVM chains need password to decrypt the mnemonic
+        const password = await askPassword();
+        result = await BackgroundExecutor.signPersonalMessage(
+          message,
+          accountNumber,
+          password
+        );
+      }
 
-      if (result.success) {
-        setSignature(result.bytes);
+      if (result?.success) {
+        setSignature(result.bytes || result.signature);
         Alert.alert('Success', 'Message signed successfully!');
       } else {
         throw new Error(result.message || 'Failed to sign message');
@@ -91,10 +103,10 @@ const SignMessage = () => {
 
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.contentContainer}>
-          {isEVMNetwork ? (
+          {isSupported ? (
             <>
               <ThemedText style={styles.description}>
-                Sign a message with your EVM private key. This creates a cryptographic proof
+                Sign a message with your {isSparkNetwork ? 'Spark identity' : 'EVM private'} key. This creates a cryptographic proof
                 that you control this wallet address on the {network} network.
               </ThemedText>
 
@@ -142,7 +154,7 @@ const SignMessage = () => {
 
               {signature ? (
                 <View style={styles.resultSection}>
-                  <ThemedText style={styles.resultLabel}>EVM Signature:</ThemedText>
+                  <ThemedText style={styles.resultLabel}>{isSparkNetwork ? 'Spark' : 'EVM'} Signature:</ThemedText>
                   <View style={styles.signatureContainer}>
                     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                       <Text style={styles.signatureText}>{signature}</Text>
@@ -166,10 +178,10 @@ const SignMessage = () => {
             <View style={styles.unsupportedSection}>
               <Ionicons name="alert-circle-outline" size={48} color="rgba(255, 255, 255, 0.4)" />
               <ThemedText style={styles.unsupportedText}>
-                Message signing is only available on EVM-compatible networks.
+                Message signing is only available on EVM-compatible networks and Spark.
               </ThemedText>
               <ThemedText style={styles.unsupportedSubtext}>
-                Please switch to an EVM-compatible network (Rootstock, Botanix, etc.) from the home screen to use this feature.
+                Please switch to a supported network (Rootstock, Botanix, Spark, etc.) from the home screen to use this feature.
               </ThemedText>
             </View>
           )}

--- a/mobile/src/modules/background-executor.ts
+++ b/mobile/src/modules/background-executor.ts
@@ -230,6 +230,44 @@ export const BackgroundExecutor: IBackgroundCaller = {
     }
   },
 
+  async signSparkMessage(message, accountNumber, password) {
+    try {
+      // Get the submnemonic for the account
+      const submnemonic = await SecureStorage.getItem(STORAGE_KEY_SUB_MNEMONIC + accountNumber);
+
+      if (!submnemonic) {
+        return {
+          success: false,
+          signature: '',
+          message: 'No submnemonic found for this account. Please reinstall the app.',
+        };
+      }
+
+      // Get or initialize the Spark wallet
+      const wallet = await BackgroundExecutor.lazyInitWallet(NETWORK_SPARK, accountNumber);
+
+      if (!(wallet instanceof SparkWallet)) {
+        return {
+          success: false,
+          signature: '',
+          message: 'Failed to initialize Spark wallet',
+        };
+      }
+
+      // Sign the message with the identity key
+      const signature = await wallet.signMessageWithIdentityKey(message);
+
+      return { success: true, signature };
+    } catch (error: any) {
+      console.error('Error signing Spark message:', error);
+      return {
+        success: false,
+        signature: '',
+        message: error.message || 'Failed to sign message with Spark wallet',
+      };
+    }
+  },
+
   async openPopup(...params: OpenPopupRequest) {
     const bridge = BrowserBridge.getInstance();
     if (bridge) {

--- a/shared/class/wallets/spark-wallet.ts
+++ b/shared/class/wallets/spark-wallet.ts
@@ -186,4 +186,49 @@ export class SparkWallet extends ArkWallet implements InterfaceLightningWallet {
 
     return await this._sdkWallet.transferTokens({ receiverSparkAddress, tokenAmount, tokenIdentifier: tokenIdentifier as Bech32mTokenIdentifier });
   }
+
+  /**
+   * Sign a message with the wallet's identity key
+   * @param message - The message to sign (string or Uint8Array)
+   * @param compact - Whether to use compact signature format (default: true)
+   * @returns The signature as a hex string
+   */
+  async signMessageWithIdentityKey(message: string | Uint8Array, compact: boolean = true): Promise<string> {
+    if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
+
+    // Convert string to Uint8Array if needed
+    const messageBytes = typeof message === 'string'
+      ? new TextEncoder().encode(message)
+      : message;
+
+    // Sign the message using the SDK's signMessageWithIdentityKey method
+    const signature = await this._sdkWallet.signMessageWithIdentityKey(messageBytes, compact);
+
+    // Convert signature to hex string if it's a Uint8Array
+    if (signature instanceof Uint8Array) {
+      return Buffer.from(signature).toString('hex');
+    }
+
+    return signature;
+  }
+
+  /**
+   * Validate a message signature against the identity key
+   * @param message - The original message
+   * @param signature - The signature to validate
+   * @returns True if the signature is valid
+   */
+  async validateMessageWithIdentityKey(message: string | Uint8Array, signature: string | Uint8Array): Promise<boolean> {
+    if (!this._sdkWallet) throw new Error('Spark wallet not initialized');
+
+    const messageBytes = typeof message === 'string'
+      ? new TextEncoder().encode(message)
+      : message;
+
+    const signatureBytes = typeof signature === 'string'
+      ? Buffer.from(signature, 'hex')
+      : signature;
+
+    return await this._sdkWallet.validateMessageWithIdentityKey(messageBytes, signatureBytes);
+  }
 }


### PR DESCRIPTION
- Implement signMessageWithIdentityKey in SparkWallet class
- Add signSparkMessage to BackgroundExecutor
- Update SignMessage UI to support both EVM and Spark networks
- Skip password prompt for Spark (uses unencrypted submnemonics)
- Add validation method for signature verification
- Update Settings to show Sign Message button for Spark network